### PR TITLE
[update-mod] overhauling update-available and update-quantity

### DIFF
--- a/service/service.py
+++ b/service/service.py
@@ -225,71 +225,69 @@ def delete_inventory(product_id, condition):
 
 
 ################################################################################
-# UPDATE AN EXISTING PRODUCT's QUANTITY 
+# UPDATE AN EXISTING PRODUCT's QUANTITY
 ################################################################################
-@app.route("/inventory/<int:product_id>/<string:condition>/<string:operation>/<int:amount>", methods=["PUT"])
-def update_stock(product_id, condition, operation, amount):
-    """Updates the inventory with the given product_id and condition"""
-    app.logger.info("Request to update quantity of product in inventory with product_id %d and condition %s", product_id, condition)
-    
-
-    if amount == 0:
-        return bad_request("Wrong update amount parameter specified . Amount can only be a non zero whole number Eg : /inventory/123/new/add/1")
-
-    if operation != "add" and operation != "sub":
-        return bad_request("Wrong operation specified. Operation can only be add or sub in http request. Eg : /inventory/123/new/add/1")
-
-    inventory = Inventory.find(product_id, condition)
-    if not inventory:
-        raise NotFound("Inventory with product_id {} and condition {} was not found.".format(product_id, condition))
-    
-    msg_tmp = " "
-
-    if operation == "add":
-        inventory.quantity = inventory.quantity + amount
-        msg_tmp = "Added "
-    else:
-        inventory.quantity = inventory.quantity - amount
-        if inventory.quantity < 0:
-            return forbidden("Unable to perform operation. Current stock level is lesser than specified subtract amount. Stock quantity can't become negative")
-        msg_tmp = "Removed "
-
-    if inventory.quantity==0:
-        inventory.available=0
-        
-    inventory.update()
-    app.logger.info(msg_tmp+"%d items having product_id %d and condition %s.", amount, product_id, condition)
-    return make_response(jsonify(inventory.serialize()), status.HTTP_200_OK)
+# @app.route("/inventory/<int:product_id>/<string:condition>/<string:operation>/<int:amount>", methods=["PUT"])
+# def update_stock(product_id, condition, operation, amount):
+#     """Updates the inventory with the given product_id and condition"""
+#     app.logger.info("Request to update quantity of product in inventory with product_id %d and condition %s", product_id, condition)
+#
+#
+#     if amount == 0:
+#         return bad_request("Wrong update amount parameter specified . Amount can only be a non zero whole number Eg : /inventory/123/new/add/1")
+#
+#     if operation != "add" and operation != "sub":
+#         return bad_request("Wrong operation specified. Operation can only be add or sub in http request. Eg : /inventory/123/new/add/1")
+#
+#     inventory = Inventory.find(product_id, condition)
+#     if not inventory:
+#         raise NotFound("Inventory with product_id {} and condition {} was not found.".format(product_id, condition))
+#
+#     msg_tmp = " "
+#
+#     if operation == "add":
+#         inventory.quantity = inventory.quantity + amount
+#         msg_tmp = "Added "
+#     else:
+#         inventory.quantity = inventory.quantity - amount
+#         if inventory.quantity < 0:
+#             return forbidden("Unable to perform operation. Current stock level is lesser than specified subtract amount. Stock quantity can't become negative")
+#         msg_tmp = "Removed "
+#
+#     if inventory.quantity==0:
+#         inventory.available=0
+#
+#     inventory.update()
+#     app.logger.info(msg_tmp+"%d items having product_id %d and condition %s.", amount, product_id, condition)
+#     return make_response(jsonify(inventory.serialize()), status.HTTP_200_OK)
 
 ################################################################################
 # UPDATE AN EXISTING PRODUCT'S AVAILABILITY
 ################################################################################
-@app.route("/inventory/<int:product_id>/<string:condition>/<int:available>", methods=["PUT"])
-def update_availablility(product_id, condition, available):
-    """Updates the available attribute for the given product_id and condition"""
-    app.logger.info("Sent request to update availability for the product ID %d and condition %s", product_id, condition)
-    
-    if available != 0 or available!=1:
-        return bad_request("Incorrect value for available, can only accept 0 or 1")
-
-    prod = Inventory.find(product_id, condition)
-    if not prod:
-        raise NotFound("The product ID, condition pair does not exist.")
-
-    if prod.quantity==0 and available==1:
-        return forbidden("This product is currently out of stock and cannot be made available")
-
-    prod.available = available
-    prod.update()
-
-    
-    if prod.available==1:
-        app.logger.info("The product with ID %d that satisfies the condition %s is now available.", product_id, condition)
-    else:
-        app.logger.info("The product with ID %d that satisfies the condition %s is now unavailable.", product_id, condition)
-    return make_response(jsonify(prod.serialize()), status.HTTP_200_OK)
-
-
+# @app.route("/inventory/<int:product_id>/<string:condition>/<int:available>", methods=["PUT"])
+# def update_availablility(product_id, condition, available):
+#     """Updates the available attribute for the given product_id and condition"""
+#     app.logger.info("Sent request to update availability for the product ID %d and condition %s", product_id, condition)
+#
+#     if available != 0 or available!=1:
+#         return bad_request("Incorrect value for available, can only accept 0 or 1")
+#
+#     prod = Inventory.find(product_id, condition)
+#     if not prod:
+#         raise NotFound("The product ID, condition pair does not exist.")
+#
+#     if prod.quantity==0 and available==1:
+#         return forbidden("This product is currently out of stock and cannot be made available")
+#
+#     prod.available = available
+#     prod.update()
+#
+#
+#     if prod.available==1:
+#         app.logger.info("The product with ID %d that satisfies the condition %s is now available.", product_id, condition)
+#     else:
+#         app.logger.info("The product with ID %d that satisfies the condition %s is now unavailable.", product_id, condition)
+#     return make_response(jsonify(prod.serialize()), status.HTTP_200_OK)
 
 ################################################################################
 #  U T I L I T Y   F U N C T I O N S

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -59,6 +59,24 @@ class InventoryAPITest(TestCase):
         data = resp.get_json()
         self.assertEqual(data["name"], service.DEMO_MSG)
 
+    def _create_inventories(self, count):
+        """ Factory method to create inventory products in bulk """
+        inventories = []
+        for _ in range(count):
+            test_inventory = InventoryFactory()
+            resp = self.app.post(
+                "/inventory", json=test_inventory.serialize(), content_type="application/json"
+            )
+            self.assertEqual(
+                resp.status_code, status.HTTP_201_CREATED, "Could not create test inventory"
+            )
+            new_inventory = resp.get_json()
+            test_inventory.product_id = new_inventory["product_id"]
+            inventories.append(test_inventory)
+        return inventories
+
+    ##################################################################
+    # Testing POST
     def test_create_inventory(self):
         """ Create a new inventory """
         test_inventory = InventoryFactory()
@@ -90,23 +108,8 @@ class InventoryAPITest(TestCase):
         self.assertEqual(new_inventory["available"], test_inventory.serialize()['available'], "Availability does not match")
         self.assertEqual(new_inventory["condition"], test_inventory.serialize()['condition'], "Conditions do not match")
 
-    # -
-    def _create_inventories(self, count):
-        """ Factory method to create inventory products in bulk """
-        inventories = []
-        for _ in range(count):
-            test_inventory = InventoryFactory()
-            resp = self.app.post(
-                "/inventory", json=test_inventory.serialize(), content_type="application/json"
-            )
-            self.assertEqual(
-                resp.status_code, status.HTTP_201_CREATED, "Could not create test inventory"
-            )
-            new_inventory = resp.get_json()
-            test_inventory.product_id = new_inventory["product_id"]
-            inventories.append(test_inventory)
-        return inventories
-
+    ##################################################################
+    # Testing GET
     def test_list_inventory(self):
         """Get a list of products in inventory"""
         self._create_inventories(5)
@@ -155,6 +158,8 @@ class InventoryAPITest(TestCase):
         resp = self.app.get("/inventory/{}".format(pid+3), content_type="application/json")
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
 
+    ##################################################################
+    # Testing PUT
     def test_update_inventory(self):
         """Update an existing product in  Inventory"""
         test_inventory = InventoryFactory()
@@ -193,96 +198,116 @@ class InventoryAPITest(TestCase):
         )
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
 
+    #
+    # def test_update_stock_quantity(self):
+    #     """Update stock quantity for a given product in Inventory"""
+    #     test_inventory = InventoryFactory()
+    #     resp = self.app.post(
+    #         "/inventory", json=test_inventory.serialize(), content_type="application/json"
+    #     )
+    #     new_inventory = resp.get_json()
+    #     self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+    #     resp = self.app.put("/inventory/{}/{}/sub/{}".format(new_inventory["product_id"],new_inventory["condition"],new_inventory["quantity"]))
+    #     self.assertEqual(resp.status_code, status.HTTP_200_OK)
+    #
+    # def test_update_stock_quantity_2(self):
+    #     """Update stock quantity for a given product in Inventory"""
+    #     test_inventory = InventoryFactory()
+    #     resp = self.app.post(
+    #         "/inventory", json=test_inventory.serialize(), content_type="application/json"
+    #     )
+    #     new_inventory = resp.get_json()
+    #     self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+    #     resp = self.app.put("/inventory/{}/{}/sub/{}".format(new_inventory["product_id"],new_inventory["condition"],new_inventory["quantity"]+1))
+    #     self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+    #
+    # def test_update_stock_quantity_3(self):
+    #     """Update stock quantity for a given product in Inventory"""
+    #     test_inventory = InventoryFactory()
+    #     resp = self.app.post(
+    #         "/inventory", json=test_inventory.serialize(), content_type="application/json"
+    #     )
+    #     new_inventory = resp.get_json()
+    #     self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+    #     resp = self.app.put("/inventory/{}/{}/add/{}".format(new_inventory["product_id"],new_inventory["condition"],new_inventory["quantity"]))
+    #     self.assertEqual(resp.status_code, status.HTTP_200_OK)
+    #
+    # def test_update_stock_quantity_4(self):
+    #     """Update stock quantity for a given product in Inventory"""
+    #     test_inventory = InventoryFactory()
+    #     resp = self.app.post(
+    #         "/inventory", json=test_inventory.serialize(), content_type="application/json"
+    #     )
+    #     new_inventory = resp.get_json()
+    #     self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+    #     resp = self.app.put("/inventory/{}/{}/sub/{}".format(new_inventory["product_id"],new_inventory["condition"],new_inventory["quantity"]-8))
+    #     self.assertEqual(resp.status_code, status.HTTP_200_OK)
+    # 
+    # def test_update_stock_quantity_5(self):
+    #     """Update stock quantity for a given product in Inventory"""
+    #     test_inventory = InventoryFactory()
+    #     resp = self.app.post(
+    #         "/inventory", json=test_inventory.serialize(), content_type="application/json"
+    #     )
+    #     new_inventory = resp.get_json()
+    #     self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+    #     resp = self.app.put("/inventory/{}/{}/sub/0".format(new_inventory["product_id"],new_inventory["condition"]))
+    #     self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+    #
+    # def test_update_stock_quantity_6(self):
+    #     """Update stock quantity for a given product in Inventory"""
+    #     test_inventory = InventoryFactory()
+    #     resp = self.app.post(
+    #         "/inventory", json=test_inventory.serialize(), content_type="application/json"
+    #     )
+    #     new_inventory = resp.get_json()
+    #     self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+    #     resp = self.app.put("/inventory/{}/{}/sub/0".format(new_inventory["product_id"],new_inventory["condition"]))
+    #     self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+    #
+    # def test_update_stock_quantity_7(self):
+    #     """Update stock quantity for a given product in Inventory"""
+    #     test_inventory = InventoryFactory()
+    #     resp = self.app.post(
+    #         "/inventory", json=test_inventory.serialize(), content_type="application/json"
+    #     )
+    #     new_inventory = resp.get_json()
+    #     self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+    #     resp = self.app.put("/inventory/{}/{}/subh/5".format(new_inventory["product_id"],new_inventory["condition"]))
+    #     self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+    #
+    # def test_update_stock_quantity_8(self):
+    #     """Update stock quantity for a given product in Inventory"""
+    #     test_inventory = InventoryFactory()
+    #     resp = self.app.post(
+    #         "/inventory", json=test_inventory.serialize(), content_type="application/json"
+    #     )
+    #     new_inventory = resp.get_json()
+    #     self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+    #     resp = self.app.put("/inventory/{}/{}/add/5".format(new_inventory["product_id"]+4,new_inventory["condition"]))
+    #     self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+    #
+    # def test_update_availability(self):
+    #     """Update an existing product's availability in the inventory"""
+    #     test_inventory = InventoryFactory()
+    #     resp = self.app.post(
+    #         "/inventory", json=test_inventory.serialize(), content_type="application/json"
+    #     )
+    #     self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+    #
+    #     new_inventory = resp.get_json()
+    #     new_inventory["available"] = 0
+    #     resp = self.app.put(
+    #         "/inventory/{}/{}".format(new_inventory["product_id"], new_inventory["condition"]),
+    #         json=new_inventory,
+    #         content_type="application/json",
+    #     )
+    #     self.assertEqual(resp.status_code, status.HTTP_200_OK)
+    #     final_inventory = resp.get_json()
+    #     self.assertEqual(final_inventory["available"], 0, "The available parameter is not what was expected")
 
-
-    def test_update_stock_quantity(self):
-        """Update stock quantity for a given product in Inventory"""
-        test_inventory = InventoryFactory()
-        resp = self.app.post(
-            "/inventory", json=test_inventory.serialize(), content_type="application/json"
-        )
-        new_inventory = resp.get_json()
-        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
-        resp = self.app.put("/inventory/{}/{}/sub/{}".format(new_inventory["product_id"],new_inventory["condition"],new_inventory["quantity"]))
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
-
-    def test_update_stock_quantity_2(self):
-        """Update stock quantity for a given product in Inventory"""
-        test_inventory = InventoryFactory()
-        resp = self.app.post(
-            "/inventory", json=test_inventory.serialize(), content_type="application/json"
-        )
-        new_inventory = resp.get_json()
-        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
-        resp = self.app.put("/inventory/{}/{}/sub/{}".format(new_inventory["product_id"],new_inventory["condition"],new_inventory["quantity"]+1))
-        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
-
-    def test_update_stock_quantity_3(self):
-        """Update stock quantity for a given product in Inventory"""
-        test_inventory = InventoryFactory()
-        resp = self.app.post(
-            "/inventory", json=test_inventory.serialize(), content_type="application/json"
-        )
-        new_inventory = resp.get_json()
-        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
-        resp = self.app.put("/inventory/{}/{}/add/{}".format(new_inventory["product_id"],new_inventory["condition"],new_inventory["quantity"]))
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
-
-    def test_update_stock_quantity_4(self):
-        """Update stock quantity for a given product in Inventory"""
-        test_inventory = InventoryFactory()
-        resp = self.app.post(
-            "/inventory", json=test_inventory.serialize(), content_type="application/json"
-        )
-        new_inventory = resp.get_json()
-        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
-        resp = self.app.put("/inventory/{}/{}/sub/{}".format(new_inventory["product_id"],new_inventory["condition"],new_inventory["quantity"]-8))
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)   
-
-    def test_update_stock_quantity_5(self):
-        """Update stock quantity for a given product in Inventory"""
-        test_inventory = InventoryFactory()
-        resp = self.app.post(
-            "/inventory", json=test_inventory.serialize(), content_type="application/json"
-        )
-        new_inventory = resp.get_json()
-        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
-        resp = self.app.put("/inventory/{}/{}/sub/0".format(new_inventory["product_id"],new_inventory["condition"]))
-        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)   
-
-    def test_update_stock_quantity_6(self):
-        """Update stock quantity for a given product in Inventory"""
-        test_inventory = InventoryFactory()
-        resp = self.app.post(
-            "/inventory", json=test_inventory.serialize(), content_type="application/json"
-        )
-        new_inventory = resp.get_json()
-        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
-        resp = self.app.put("/inventory/{}/{}/sub/0".format(new_inventory["product_id"],new_inventory["condition"]))
-        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST) 
-
-    def test_update_stock_quantity_7(self):
-        """Update stock quantity for a given product in Inventory"""
-        test_inventory = InventoryFactory()
-        resp = self.app.post(
-            "/inventory", json=test_inventory.serialize(), content_type="application/json"
-        )
-        new_inventory = resp.get_json()
-        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
-        resp = self.app.put("/inventory/{}/{}/subh/5".format(new_inventory["product_id"],new_inventory["condition"]))
-        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST) 
-
-    def test_update_stock_quantity_8(self):
-        """Update stock quantity for a given product in Inventory"""
-        test_inventory = InventoryFactory()
-        resp = self.app.post(
-            "/inventory", json=test_inventory.serialize(), content_type="application/json"
-        )
-        new_inventory = resp.get_json()
-        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
-        resp = self.app.put("/inventory/{}/{}/add/5".format(new_inventory["product_id"]+4,new_inventory["condition"]))
-        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND) 
-
+    ##################################################################
+    # Testing DELETE
     def test_delete_inventory(self):
         """Delete a product from the inventory"""
         test_inventory = self._create_inventories(1)[0]
@@ -296,27 +321,8 @@ class InventoryAPITest(TestCase):
             "/inventory/{}/{}".format(test_inventory.product_id, test_inventory.condition), content_type="application/json"
         )
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
-        
-    def test_update_availability(self):
-        """Update an existing product's availability in the inventory"""
-        test_inventory = InventoryFactory()
-        resp = self.app.post(
-            "/inventory", json=test_inventory.serialize(), content_type="application/json"
-        )
-        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
 
-        new_inventory = resp.get_json()
-        new_inventory["available"] = 0
-        resp = self.app.put(
-            "/inventory/{}/{}".format(new_inventory["product_id"], new_inventory["condition"]),
-            json=new_inventory,
-            content_type="application/json",
-        )
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        final_inventory = resp.get_json()
-        self.assertEqual(final_inventory["available"], 0, "The available parameter is not what was expected")
-
-        
+    ##################################################################
     def test_wrong_content_type(self):
         """trigger wrong content type error"""
         test_inventory = InventoryFactory()


### PR DESCRIPTION
We’ll have to change the update API altogether.
The resource URI must only contain the ```product_id``` and any values that need to be changed should be included in the body.
What we can do is disable the ```update_availability``` and ```update_stock``` for now, and include it as sub-methods in the regular ```update_inventory```.