### PR TITLE
[ibm-cd] manifest.yml and travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-    - "3.6"
+    - "3.7.9"
 
 # command to install dependencies
 install:

--- a/manifest.yml
+++ b/manifest.yml
@@ -13,6 +13,7 @@ applications:
   timeout: 180
   services:
   - Inventory-Prod
+  - Inventory-Test
   env:
     FLASK_APP : service:app
     FLASK_DEBUG : false


### PR DESCRIPTION
manifest.yml: added Inventory-Prod in service
.travis.yml: python 3.6 -> 3.7.9